### PR TITLE
Propagate MixinErrors as MixinApplicatorExceptions with context

### DIFF
--- a/src/main/java/org/spongepowered/asm/mixin/transformer/MixinApplicatorStandard.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/MixinApplicatorStandard.java
@@ -357,8 +357,11 @@ class MixinApplicatorStandard {
             ex.prepend(this.activities);
             throw ex;
         } catch (Exception ex) {
-            throw new MixinApplicatorException(current, "Unexpecteded " + ex.getClass().getSimpleName() + " whilst applying the mixin class:", ex,
+            throw new MixinApplicatorException(current, "Unexpected " + ex.getClass().getSimpleName() + " whilst applying the mixin class:", ex,
                     this.activities);
+        } catch (MixinError ex) {
+            throw new MixinApplicatorException(current, "Unexpected " + ex.getClass().getSimpleName() + " whilst applying the mixin class:", ex,
+                this.activities);
         }
 
         this.applySourceMap(this.context);


### PR DESCRIPTION
Many internal Mixin errors, particularly InjectionErrors, are raised as the result of invalid mixins (e.g. failed injection check as the mixin was compiled for a different Minecraft version) or mixin conflicts that are not issues in Mixin itself. These MixinErrors don't currently get handled by IMixinErrorHandler handlers, and when propagated to more generic error handling code don't have much machine-readable context.

Wrapping these errors in MixinApplicatorExceptions allows them to be handled by existing IMixinErrorHandler implementations in the apply error phase, and attaching this context allows Mixin callers to reason about the cause of mixin errors and present them in a more user-friendly way.

MixinApplicatorStandard seems like the most appropriate place to insert context of the current mixin and activity stack similarly to the existing Exception handling, and doesn't require MixinError to change how it is constructed and used by internal Mixin code.